### PR TITLE
fix: root permission grant

### DIFF
--- a/app/src/main/java/xyz/wingio/logra/utils/Root.kt
+++ b/app/src/main/java/xyz/wingio/logra/utils/Root.kt
@@ -11,7 +11,7 @@ import xyz.wingio.logra.BuildConfig
 suspend fun grantPermissionsWithRoot() = withContext(Dispatchers.IO) {
     val process = Runtime
         .getRuntime()
-        .exec("su -c 'pm grant ${BuildConfig.APPLICATION_ID} ${Manifest.permission.READ_LOGS}'")
+        .exec("su -c pm grant ${BuildConfig.APPLICATION_ID} ${Manifest.permission.READ_LOGS}")
         .apply { waitFor() }
 
     if (process.exitValue() != 0) {

--- a/app/src/main/java/xyz/wingio/logra/utils/Root.kt
+++ b/app/src/main/java/xyz/wingio/logra/utils/Root.kt
@@ -9,8 +9,12 @@ import xyz.wingio.logra.BuildConfig
  * Uses root to grant the app [Manifest.permission.READ_LOGS] permission.
  */
 suspend fun grantPermissionsWithRoot() = withContext(Dispatchers.IO) {
-    val process = Runtime.getRuntime().exec(
-        "su -c 'pm grant ${BuildConfig.APPLICATION_ID} ${Manifest.permission.READ_LOGS}'"
-    )
-    process.waitFor()
+    val process = Runtime
+        .getRuntime()
+        .exec("su -c 'pm grant ${BuildConfig.APPLICATION_ID} ${Manifest.permission.READ_LOGS}'")
+        .apply { waitFor() }
+
+    if (process.exitValue() != 0) {
+        throw Error("Failed to grant log permission with root! Error ${process.exitValue()}")
+    }
 }


### PR DESCRIPTION
calls to `grantPermissionsWithRoot` should handle the possibility of an error being thrown (i dont touch ui)